### PR TITLE
Minor homepage changes.

### DIFF
--- a/components/Content.js
+++ b/components/Content.js
@@ -109,8 +109,6 @@ class Content extends React.Component {
     const windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"];
     let os;
 
-    console.log('platform', platform);
-
     if (macosPlatforms.indexOf(platform) !== -1) {
       os = "Mac";
     } else if (windowsPlatforms.indexOf(platform) !== -1) {
@@ -118,8 +116,6 @@ class Content extends React.Component {
     } else if (!os && /Linux/.test(platform)) {
       os = "Linux";
     }
-
-    console.log('os', os);
 
     return os;
   };

--- a/components/Content.js
+++ b/components/Content.js
@@ -115,6 +115,8 @@ class Content extends React.Component {
       os = "Windows";
     } else if (!os && /Linux/.test(platform)) {
       os = "Linux";
+    } else {
+      os = "Mac";
     }
 
     return os;

--- a/components/Content.js
+++ b/components/Content.js
@@ -135,7 +135,7 @@ class Content extends React.Component {
             subtitles. A simple design, <strong>drag &amp; drop</strong> search,
             and <strong>automatic downloading &amp; renaming</strong> let you
             just start watching. Caption is <strong>multi-platform</strong>,
-            open-source, and build entirely on web technology.
+            open-source, and built entirely on web technology.
           </p>
           <DownloadButton currentSystemName={platform} systems={systems} />
         </div>

--- a/components/Content.js
+++ b/components/Content.js
@@ -50,7 +50,7 @@ class Content extends React.Component {
     super(props);
 
     this.state = {
-      platform: "Windows",
+      platform: null,
       systems: [
         {
           name: "Mac",
@@ -109,6 +109,8 @@ class Content extends React.Component {
     const windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"];
     let os;
 
+    console.log('platform', platform);
+
     if (macosPlatforms.indexOf(platform) !== -1) {
       os = "Mac";
     } else if (windowsPlatforms.indexOf(platform) !== -1) {
@@ -116,6 +118,8 @@ class Content extends React.Component {
     } else if (!os && /Linux/.test(platform)) {
       os = "Linux";
     }
+
+    console.log('os', os);
 
     return os;
   };

--- a/components/DownloadButton.js
+++ b/components/DownloadButton.js
@@ -24,6 +24,21 @@ class DownloadButton extends React.Component {
       return currentSystemName === system.name;
     })[0];
 
+    if (!currentSystem) {
+      return (
+        <div>
+          <div className="button-holder" />
+          <style jsx>
+            {`
+              .button-holder {
+                height: 39px;
+              }
+            `}
+          </style>
+        </div>
+      );
+    }
+
     return (
       <div>
         <div className="button-wrapper">

--- a/components/DownloadButton.js
+++ b/components/DownloadButton.js
@@ -24,6 +24,7 @@ class DownloadButton extends React.Component {
       return currentSystemName === system.name;
     })[0];
 
+    // Hide download button until we found the users's platform.
     if (!currentSystem) {
       return (
         <div>

--- a/components/Video.js
+++ b/components/Video.js
@@ -37,6 +37,13 @@ const Video = () => (
           background-size: 448px 444px;
         }
       }
+
+      @media (max-width: 320px) {
+        div {
+          background-size: 380px 380px;
+          background-position: center;
+        }
+      }
     `}</style>
   </section>
 );


### PR DESCRIPTION
- Hide download button until right platform has been found. Show placeholder to prevent flash of missing content. Also, don't set initial platform state to Windows. Fall back to Mac for unknown platforms.
- Correct typo on homepage.
- App image should scale correctly on small devices (like iPhone 5).